### PR TITLE
Deploy: admin bootstrap, server browser entry, and TTS worker fixes

### DIFF
--- a/Docker/server_config.prod.toml
+++ b/Docker/server_config.prod.toml
@@ -24,6 +24,9 @@ lobbyenabled = true
 [console]
 # SECURITY: behind a reverse proxy, loopback == the proxy. Never grant loopback admin.
 loginlocal = false
+# Auto-grant full host (all admin flags) to this account on join. Safe ONLY with auth.mode=1
+# (names tied to real SS14 accounts). Override per-deploy via $SS14_HOST_USER. Empty = disabled.
+login_host_user = "TheLacrox"
 
 [hub]
 advertise = true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,7 @@ set -- "$@" --cvar "console.loginlocal=false"
 [ -n "$SS14_AUTH_MODE" ]     && set -- "$@" --cvar "auth.mode=$SS14_AUTH_MODE"
 [ -n "$SS14_TTS_ENABLED" ]   && set -- "$@" --cvar "tts.enabled=$SS14_TTS_ENABLED"
 [ -n "$SS14_TTS_CONN" ]      && set -- "$@" --cvar "tts.connection_string=$SS14_TTS_CONN"
+[ -n "$SS14_HOST_USER" ]     && set -- "$@" --cvar "console.login_host_user=$SS14_HOST_USER"
 
 # Domain-derived launcher routing (HTTPS status via proxy, UDP gameplay direct).
 if [ -n "$SS14_DOMAIN" ]; then


### PR DESCRIPTION
@
Deploy/config + TTS bundle. All `_Capibara` deploy files, docs, and isolated TTS code — no upstream game code. Combined into one PR to minimise merges.

## 1. Admin bootstrap
- `console.login_host_user = "TheLacrox"` (`server_config.prod.toml`) + `SS14_HOST_USER` override (`entrypoint.sh`). Named account auto-promoted to full host on join (`AdminManager.LoadAdminDataCore` → `AdminFlagsHelper.Everything`), survives fresh data volumes, no SQLite editing. Safe only with `auth.mode=1`.

## 2. Public server browser entry
- `game.hostname` + Spanish `game.desc`, `soft_max_players=50`, `role_timers=false`, `round_end_pvs_overrides=false`.
- `hub.tags = lang:es,region:es`.
- `[infolinks]` discord / website / wiki launcher buttons.
- `server.uptime_restart_minutes = 480` — non-disruptive 8h auto-restart.
- `docker-compose.yml`: `SS14_HOSTNAME` default empty so the baked hostname wins unless overridden in Dokploy.

## 3. TTS worker fixes
- `Dockerfile.tts`: install `ffmpeg` (worker needs it for MP3/WAV → OGG; `python:3.12-slim` lacks it → all synthesis was failing "ffmpeg not found").
- `Tools/tts_worker.py`: catch `redis.TimeoutError` from idle BLPOP (redis-py uses the BLPOP timeout as socket read timeout) instead of logging it as an unexpected error.

## 4. TTS Spanish numbers (folded in from #6)
- `NumberConverter.cs`: was expanding digits into **English** words before TTS, so the Spanish voice read English numbers. Rewrote to Spanish 0–999 (`ciento veintitrés`, `cien`/`ciento`, `quinientos`, `y` joiner).
- `NumberConverterTest.cs`: 21 NUnit cases, all passing.

## Docs
- `CLAUDE.md`: admin bootstrap, Branch Protection section, ffmpeg note.

## Verification (full Docker stack, headless)
Rebuilt `docker compose` from source and exercised it in-container:
- Worker E2E: synthetic job → edge-tts → **ffmpeg → valid OGG** (24125 B, `OggS`, `\x00` end marker).
- game-server boots, migrates `/data/preferences.db`, connects to `redis:6379` for TTS.
- `/status` + `/info` render the new name, tags, desc, and the 3 info links.
- `NumberConverterTest`: 21/21 pass.
@