### PR TITLE
Fix(tts): spell numbers in Spanish instead of English

### DIFF
--- a/Content.Server/_Capibara/TTS/NumberConverter.cs
+++ b/Content.Server/_Capibara/TTS/NumberConverter.cs
@@ -6,24 +6,42 @@ using System.Text.RegularExpressions;
 namespace Content.Server._Capibara.TTS;
 
 /// <summary>
-/// Converts numbers in text to their word representations for more natural TTS output.
+/// Converts numbers in text to their Spanish word representations for more natural TTS output.
+/// The server is Spanish-first, so numbers are spelled out in Spanish (e.g. 123 -> "ciento veintitrés").
 /// </summary>
 public static partial class NumberConverter
 {
+    // 0-19 (irregular forms).
     private static readonly string[] Ones =
     {
-        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
-        "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
-        "seventeen", "eighteen", "nineteen"
+        "cero", "uno", "dos", "tres", "cuatro", "cinco", "seis", "siete", "ocho", "nueve",
+        "diez", "once", "doce", "trece", "catorce", "quince", "dieciséis",
+        "diecisiete", "dieciocho", "diecinueve"
     };
 
+    // 20-29 are written as a single word in Spanish.
+    private static readonly string[] Twenties =
+    {
+        "veinte", "veintiuno", "veintidós", "veintitrés", "veinticuatro", "veinticinco",
+        "veintiséis", "veintisiete", "veintiocho", "veintinueve"
+    };
+
+    // Tens, indexed by number / 10. 30+ join the ones with " y " (e.g. "treinta y uno").
     private static readonly string[] Tens =
     {
-        "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
+        "", "", "veinte", "treinta", "cuarenta", "cincuenta", "sesenta", "setenta", "ochenta", "noventa"
+    };
+
+    // Hundreds, indexed by number / 100. Index 1 ("ciento") is only used for 101-199;
+    // exactly 100 is the apocopated "cien" (handled in NumberToWords).
+    private static readonly string[] Hundreds =
+    {
+        "", "ciento", "doscientos", "trescientos", "cuatrocientos", "quinientos",
+        "seiscientos", "setecientos", "ochocientos", "novecientos"
     };
 
     /// <summary>
-    /// Replace numeric sequences in text with word equivalents.
+    /// Replace numeric sequences in text with Spanish word equivalents.
     /// Only converts numbers up to 999 to keep output reasonable.
     /// </summary>
     public static string ConvertNumbersToWords(string text)
@@ -45,20 +63,23 @@ public static partial class NumberConverter
         if (number < 20)
             return Ones[number];
 
+        if (number < 30)
+            return Twenties[number - 20];
+
         if (number < 100)
         {
-            var result = Tens[number / 10];
-            if (number % 10 != 0)
-                result += " " + Ones[number % 10];
-            return result;
+            var tens = Tens[number / 10];
+            var remainder = number % 10;
+            return remainder == 0 ? tens : tens + " y " + Ones[remainder];
         }
 
         // 100-999
-        var hundreds = Ones[number / 100] + " hundred";
-        var remainder = number % 100;
-        if (remainder == 0)
-            return hundreds;
-        return hundreds + " and " + NumberToWords(remainder);
+        if (number == 100)
+            return "cien";
+
+        var hundreds = Hundreds[number / 100];
+        var rest = number % 100;
+        return rest == 0 ? hundreds : hundreds + " " + NumberToWords(rest);
     }
 
     [GeneratedRegex(@"\b\d+\b")]

--- a/Content.Tests/Server/_Capibara/TTS/NumberConverterTest.cs
+++ b/Content.Tests/Server/_Capibara/TTS/NumberConverterTest.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 Capibara Station Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server._Capibara.TTS;
+using NUnit.Framework;
+
+namespace Content.Tests.Server._Capibara.TTS
+{
+    [TestFixture]
+    public sealed class NumberConverterTest
+    {
+        // Spanish-first server: numbers must be spelled out in Spanish, not English.
+        [Test]
+        [TestCase("0", "cero")]
+        [TestCase("1", "uno")]
+        [TestCase("15", "quince")]
+        [TestCase("16", "dieciséis")]
+        [TestCase("20", "veinte")]
+        [TestCase("21", "veintiuno")]
+        [TestCase("23", "veintitrés")]
+        [TestCase("30", "treinta")]
+        [TestCase("31", "treinta y uno")]
+        [TestCase("45", "cuarenta y cinco")]
+        [TestCase("99", "noventa y nueve")]
+        [TestCase("100", "cien")]
+        [TestCase("101", "ciento uno")]
+        [TestCase("123", "ciento veintitrés")]
+        [TestCase("200", "doscientos")]
+        [TestCase("215", "doscientos quince")]
+        [TestCase("500", "quinientos")]
+        [TestCase("999", "novecientos noventa y nueve")]
+        public void ConvertsToSpanish(string input, string expected)
+        {
+            Assert.That(NumberConverter.ConvertNumbersToWords(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ConvertsNumbersEmbeddedInText()
+        {
+            Assert.That(
+                NumberConverter.ConvertNumbersToWords("Quedan 3 minutos y 21 segundos"),
+                Is.EqualTo("Quedan tres minutos y veintiuno segundos"));
+        }
+
+        // Out-of-range numbers are left as digits (the voice reads them in its own locale).
+        [Test]
+        [TestCase("1000", "1000")]
+        [TestCase("2024", "2024")]
+        public void LeavesOutOfRangeNumbersUnchanged(string input, string expected)
+        {
+            Assert.That(NumberConverter.ConvertNumbersToWords(input), Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
@
## Problem
TTS read numbers in English on a Spanish-first server — `123` came out as "one hundred twenty-three". A Spanish neural voice reads raw digits in Spanish on its own, so the cause was upstream text processing, not the voice.

`NumberConverter` (run on every utterance via `TTSSystem.CleanTextForTTS`) had **English** word tables and expanded digit runs into English words before the text ever reached the worker. The voice then pronounced English words.

## Fix
Rewrote `NumberConverter.cs` word tables + `NumberToWords` to Spanish (0–999) with correct grammar:
- irregular 0–29 (`dieciséis`, `veintiuno`, `veintitrés`)
- `cien` (exactly 100) vs `ciento` (101–199)
- hundreds: `doscientos … quinientos … novecientos`
- `y` joiner for 31–99 (`cuarenta y cinco`)
- out-of-range (>999) left as digits — the voice reads them in its locale

## Test
`Content.Tests/Server/_Capibara/TTS/NumberConverterTest.cs` — 21 cases (irregular ranges, hundreds, embedded-in-text, out-of-range passthrough). Verified locally:

```
Correctas! - Con error: 0, Superado: 21, Total: 21
```
@