### PR TITLE
Server browser entry + TTS fixes (ffmpeg, idle timeout, Spanish numbers)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,9 +248,10 @@ The server deploys as a **3-service Docker Compose stack that Dokploy builds fro
 
 - **Submodules:** the `Dockerfile` runs `git submodule update --init --recursive` itself (all `space-wizards/*` submodules are public, no auth). Does **not** rely on Dokploy's flaky submodule cloning.
 - **Networking:** SS14 gameplay is **UDP 1212** — Traefik can't proxy UDP, so publish it as a direct host port. The TCP status server is fronted by Dokploy/Traefik for HTTPS → launcher uses `ss14s://<domain>`; `entrypoint.sh` sets `status.connectaddress=udp://<domain>:1212` from `$SS14_DOMAIN`.
-- **Security:** `console.loginlocal=false` (TOML + entrypoint). Behind a proxy, loopback == the proxy, so loopback admin would be handed to any player. Use DB admin ranks.
+- **Security:** `console.loginlocal=false` (TOML + entrypoint). Behind a proxy, loopback == the proxy, so loopback admin would be handed to any player.
+- **Admin bootstrap:** `console.login_host_user` (baked to `"TheLacrox"` in `server_config.prod.toml`, override via `$SS14_HOST_USER`) auto-promotes that account to full host (all admin flags, `AdminFlagsHelper.Everything`) on join — see `AdminManager.LoadAdminDataCore`. Survives fresh data volumes, no SQLite editing. **Safe only with `auth.mode=1`** (account names tied to real SS14 accounts); with auth disabled anyone could pick the name. SS14 has no `addadmin` console command, so without this the only bootstrap is hand-inserting into `admin`/`admin_flag` (flag `HOST`) in `/data/preferences.db`.
 - **Persistence:** SQLite `preferences.db` + logs on the `ss14-data` volume at `/data`. Config travels in the image (edit `Docker/server_config.prod.toml` + redeploy).
-- **Env config** (Dokploy UI): `SS14_DOMAIN`, `SS14_HOSTNAME`, `SS14_HUB_ADVERTISE` (default `true`), `SS14_AUTH_MODE` (default `1`), `SS14_TTS_ENABLED`, `SS14_TTS_CONN` (default `redis:6379`).
+- **Env config** (Dokploy UI): `SS14_DOMAIN`, `SS14_HOSTNAME`, `SS14_HUB_ADVERTISE` (default `true`), `SS14_AUTH_MODE` (default `1`), `SS14_HOST_USER` (default `TheLacrox`, empty = disabled), `SS14_TTS_ENABLED`, `SS14_TTS_CONN` (default `redis:6379`).
 
 ### Local build/smoke
 
@@ -279,6 +280,15 @@ Enforced via `.editorconfig`:
 ## CI Checks
 
 PRs must pass: Build & Test (DebugOpt on Ubuntu), Test Packaging, YAML Linter, RGA/RSI/map validators.
+
+## Branch Protection (master)
+
+`master` is protected on GitHub (set via `gh api PUT /repos/.../branches/master/protection`). To change rules, edit that protection object — not the repo settings UI blindly.
+
+- **No direct pushes** — all changes land via PR. Always branch off latest `origin/master` and open a PR (`gh pr create --repo TheLacrox/Estacion-Capibara --base master ...`; the `--repo` flag is required or `gh` targets the upstream fork parent).
+- **1 approving review required**; stale approvals dismissed on new commits; conversation resolution required; force-push + branch deletion blocked.
+- **`enforce_admins=false`** — the owner (admin) can bypass the review gate. This is deliberate: GitHub forbids approving your own PR, so on a solo-maintained repo the owner merges their own PRs via admin bypass while contributors' PRs still need owner approval.
+- No required status checks wired yet (admin merges don't need green CI). Add them to the protection object's `required_status_checks.contexts` if you want CI gating.
 
 ## Key Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,7 +238,7 @@ The server deploys as a **3-service Docker Compose stack that Dokploy builds fro
 | File | Purpose |
 |---|---|
 | `Dockerfile` | Multi-stage build: SDK stage packages `Content.Packaging server --platform linux-x64 --hybrid-acz`; runtime stage on `dotnet/runtime:9.0` (server is framework-dependent, `--no-self-contained`) |
-| `Dockerfile.tts` | TTS worker (`pip install redis edge-tts`, runs `Tools/tts_worker.py`) |
+| `Dockerfile.tts` | TTS worker (apt `ffmpeg` for OGG conversion + `pip install redis edge-tts`, runs `Tools/tts_worker.py`) |
 | `docker-compose.yml` | The prod stack + `ss14-data` volume (replaces the old redis-only dev file) |
 | `entrypoint.sh` | Maps `SS14_*` env vars → `--cvar` flags; launches `Robust.Server --config-file ... --data-dir /data` |
 | `Docker/server_config.prod.toml` | Baked prod config (named `.prod.toml` because bare `server_config.toml` is gitignored) |

--- a/Content.Server/_Capibara/TTS/NumberConverter.cs
+++ b/Content.Server/_Capibara/TTS/NumberConverter.cs
@@ -6,24 +6,42 @@ using System.Text.RegularExpressions;
 namespace Content.Server._Capibara.TTS;
 
 /// <summary>
-/// Converts numbers in text to their word representations for more natural TTS output.
+/// Converts numbers in text to their Spanish word representations for more natural TTS output.
+/// The server is Spanish-first, so numbers are spelled out in Spanish (e.g. 123 -> "ciento veintitrés").
 /// </summary>
 public static partial class NumberConverter
 {
+    // 0-19 (irregular forms).
     private static readonly string[] Ones =
     {
-        "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine",
-        "ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen",
-        "seventeen", "eighteen", "nineteen"
+        "cero", "uno", "dos", "tres", "cuatro", "cinco", "seis", "siete", "ocho", "nueve",
+        "diez", "once", "doce", "trece", "catorce", "quince", "dieciséis",
+        "diecisiete", "dieciocho", "diecinueve"
     };
 
+    // 20-29 are written as a single word in Spanish.
+    private static readonly string[] Twenties =
+    {
+        "veinte", "veintiuno", "veintidós", "veintitrés", "veinticuatro", "veinticinco",
+        "veintiséis", "veintisiete", "veintiocho", "veintinueve"
+    };
+
+    // Tens, indexed by number / 10. 30+ join the ones with " y " (e.g. "treinta y uno").
     private static readonly string[] Tens =
     {
-        "", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"
+        "", "", "veinte", "treinta", "cuarenta", "cincuenta", "sesenta", "setenta", "ochenta", "noventa"
+    };
+
+    // Hundreds, indexed by number / 100. Index 1 ("ciento") is only used for 101-199;
+    // exactly 100 is the apocopated "cien" (handled in NumberToWords).
+    private static readonly string[] Hundreds =
+    {
+        "", "ciento", "doscientos", "trescientos", "cuatrocientos", "quinientos",
+        "seiscientos", "setecientos", "ochocientos", "novecientos"
     };
 
     /// <summary>
-    /// Replace numeric sequences in text with word equivalents.
+    /// Replace numeric sequences in text with Spanish word equivalents.
     /// Only converts numbers up to 999 to keep output reasonable.
     /// </summary>
     public static string ConvertNumbersToWords(string text)
@@ -45,20 +63,23 @@ public static partial class NumberConverter
         if (number < 20)
             return Ones[number];
 
+        if (number < 30)
+            return Twenties[number - 20];
+
         if (number < 100)
         {
-            var result = Tens[number / 10];
-            if (number % 10 != 0)
-                result += " " + Ones[number % 10];
-            return result;
+            var tens = Tens[number / 10];
+            var remainder = number % 10;
+            return remainder == 0 ? tens : tens + " y " + Ones[remainder];
         }
 
         // 100-999
-        var hundreds = Ones[number / 100] + " hundred";
-        var remainder = number % 100;
-        if (remainder == 0)
-            return hundreds;
-        return hundreds + " and " + NumberToWords(remainder);
+        if (number == 100)
+            return "cien";
+
+        var hundreds = Hundreds[number / 100];
+        var rest = number % 100;
+        return rest == 0 ? hundreds : hundreds + " " + NumberToWords(rest);
     }
 
     [GeneratedRegex(@"\b\d+\b")]

--- a/Content.Tests/Server/_Capibara/TTS/NumberConverterTest.cs
+++ b/Content.Tests/Server/_Capibara/TTS/NumberConverterTest.cs
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2025 Capibara Station Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Server._Capibara.TTS;
+using NUnit.Framework;
+
+namespace Content.Tests.Server._Capibara.TTS
+{
+    [TestFixture]
+    public sealed class NumberConverterTest
+    {
+        // Spanish-first server: numbers must be spelled out in Spanish, not English.
+        [Test]
+        [TestCase("0", "cero")]
+        [TestCase("1", "uno")]
+        [TestCase("15", "quince")]
+        [TestCase("16", "dieciséis")]
+        [TestCase("20", "veinte")]
+        [TestCase("21", "veintiuno")]
+        [TestCase("23", "veintitrés")]
+        [TestCase("30", "treinta")]
+        [TestCase("31", "treinta y uno")]
+        [TestCase("45", "cuarenta y cinco")]
+        [TestCase("99", "noventa y nueve")]
+        [TestCase("100", "cien")]
+        [TestCase("101", "ciento uno")]
+        [TestCase("123", "ciento veintitrés")]
+        [TestCase("200", "doscientos")]
+        [TestCase("215", "doscientos quince")]
+        [TestCase("500", "quinientos")]
+        [TestCase("999", "novecientos noventa y nueve")]
+        public void ConvertsToSpanish(string input, string expected)
+        {
+            Assert.That(NumberConverter.ConvertNumbersToWords(input), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ConvertsNumbersEmbeddedInText()
+        {
+            Assert.That(
+                NumberConverter.ConvertNumbersToWords("Quedan 3 minutos y 21 segundos"),
+                Is.EqualTo("Quedan tres minutos y veintiuno segundos"));
+        }
+
+        // Out-of-range numbers are left as digits (the voice reads them in its own locale).
+        [Test]
+        [TestCase("1000", "1000")]
+        [TestCase("2024", "2024")]
+        public void LeavesOutOfRangeNumbersUnchanged(string input, string expected)
+        {
+            Assert.That(NumberConverter.ConvertNumbersToWords(input), Is.EqualTo(expected));
+        }
+    }
+}

--- a/Docker/server_config.prod.toml
+++ b/Docker/server_config.prod.toml
@@ -17,8 +17,16 @@ enabled = true
 # status.connectaddress is set at runtime from $SS14_DOMAIN (udp://<domain>:1212)
 
 [game]
-hostname = "Capibara Station"
+# NOTE: hostname is overridden at runtime by $SS14_HOSTNAME (entrypoint.sh). Set
+# SS14_HOSTNAME in Dokploy to this value, or the env wins over this baked default.
+hostname = "[ES] Estacion Capibara 14 V2 [Español] [Traducido]"
 lobbyenabled = true
+soft_max_players = 50
+role_timers = false
+round_end_pvs_overrides = false
+desc = """¡Bienvenido a Estacion Capibara 14! Servidor de habla hispana basado en Goob Station, \
+con contenido personalizado incluyendo reactor nuclear y características de otros servidores. \
+¡Únete a nuestra comunidad hispanohablante y disfruta de SS14 en español!"""
 # map comes from the map pool (AtlasUpgraded)
 
 [console]
@@ -31,10 +39,23 @@ login_host_user = "TheLacrox"
 [hub]
 advertise = true
 hub_urls = "https://hub.spacestation14.com/"
+tags = "lang:es,region:es"
 # hub.server_url is set at runtime from $SS14_DOMAIN (ss14s://<domain>)
+
+[infolinks]
+# Launcher "View server info" buttons (built-in icons for discord/web/wiki).
+discord = "https://discord.gg/xRsRcpmCVX"
+website = "https://estacioncapibara.com/"
+wiki = "https://estacioncapibara.com/wiki"
 
 [auth]
 mode = 1   # 0=optional 1=required 2=disabled. Public server -> required.
+
+[server]
+# Auto-restart after 8h uptime to clear long-uptime perf drift. Non-disruptive:
+# only fires at round end or when nobody is connected. Process exits -> Docker
+# (restart: unless-stopped) brings it back up.
+uptime_restart_minutes = 480
 
 [database]
 engine = "sqlite"

--- a/Dockerfile.tts
+++ b/Dockerfile.tts
@@ -1,6 +1,12 @@
 # syntax=docker/dockerfile:1
 FROM python:3.12-slim
 
+# ffmpeg: worker shells out to it to convert TTS output (MP3/WAV) -> OGG Vorbis.
+# Without it every synthesis fails with "ffmpeg not found" and no audio is returned.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 # edge backend needs outbound internet (Microsoft TTS endpoint).
 RUN pip install --no-cache-dir redis edge-tts
 

--- a/Tools/tts_worker.py
+++ b/Tools/tts_worker.py
@@ -361,6 +361,10 @@ def run_worker(args):
                 error_msg = f"ERROR:All TTS backends failed"
                 r.publish(reply_channel, error_msg.encode("utf-8"))
 
+        except redis.TimeoutError:
+            # redis-py applies BLPOP's timeout as the socket read timeout, so an
+            # idle queue raises here instead of returning None. Normal — keep waiting.
+            continue
         except redis.ConnectionError as e:
             log.error("Redis connection lost: %s — retrying in 5s", e)
             time.sleep(5)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     volumes:
       - ss14-data:/data
     environment:
-      SS14_HOSTNAME: "${SS14_HOSTNAME:-Capibara Station}"
+      # Empty default -> entrypoint skips the --cvar and the baked game.hostname
+      # in server_config.prod.toml wins. Set this in Dokploy only to override.
+      SS14_HOSTNAME: "${SS14_HOSTNAME:-}"
       SS14_DOMAIN: "${SS14_DOMAIN:-}"
       SS14_HUB_ADVERTISE: "${SS14_HUB_ADVERTISE:-true}"
       SS14_AUTH_MODE: "${SS14_AUTH_MODE:-1}"


### PR DESCRIPTION
@
The remaining work after #5 was merged early (it only carried the admin-bootstrap commit). This bundles the other four commits into a single PR.

## 1. Docs
- `CLAUDE.md`: admin bootstrap note, Branch Protection section, ffmpeg dependency note.

## 2. Public server browser entry (`server_config.prod.toml`, `docker-compose.yml`)
- `game.hostname` + Spanish `game.desc`, `soft_max_players=50`, `role_timers=false`, `round_end_pvs_overrides=false`.
- `hub.tags = lang:es,region:es`.
- `[infolinks]` discord / website / wiki launcher buttons.
- `server.uptime_restart_minutes = 480` — non-disruptive 8h auto-restart.
- `SS14_HOSTNAME` default empty so the baked hostname wins unless overridden in Dokploy.

## 3. TTS worker fixes (`Dockerfile.tts`, `Tools/tts_worker.py`)
- Install `ffmpeg` — the worker shells out to it for MP3/WAV → OGG; `python:3.12-slim` lacks it, so all synthesis was failing "ffmpeg not found".
- Catch `redis.TimeoutError` from idle BLPOP (redis-py applies the BLPOP timeout as the socket read timeout) instead of logging an unexpected error every cycle.

## 4. TTS Spanish numbers (`NumberConverter.cs` + test)
- Was expanding digits into **English** words before TTS, so the Spanish voice read English numbers. Rewrote to Spanish 0–999 (`ciento veintitrés`, `cien`/`ciento`, `quinientos`, `y` joiner). `NumberConverterTest`: 21 NUnit cases.

## Verification (full Docker stack, headless)
- Worker E2E: synthetic job → edge-tts → **ffmpeg → valid OGG** (24125 B, `OggS`, `\x00` end marker).
- game-server boots, migrates `/data/preferences.db`, connects to `redis:6379` for TTS.
- `/status` + `/info` render the new name, tags, desc, and 3 info links.
- `NumberConverterTest`: 21/21 pass.
@