### PR TITLE
fix(server): disable periodic uptime auto-restart in prod

### DIFF
--- a/Docker/server_config.prod.toml
+++ b/Docker/server_config.prod.toml
@@ -52,10 +52,10 @@ wiki = "https://estacioncapibara.com/wiki"
 mode = 1   # 0=optional 1=required 2=disabled. Public server -> required.
 
 [server]
-# Auto-restart after 8h uptime to clear long-uptime perf drift. Non-disruptive:
-# only fires at round end or when nobody is connected. Process exits -> Docker
-# (restart: unless-stopped) brings it back up.
-uptime_restart_minutes = 480
+# Periodic uptime auto-restart DISABLED (0 = off; engine default). Was 480 (8h).
+# Re-enable by setting minutes > 0; when set it only fires at round end or when
+# nobody is connected, and Docker (restart: unless-stopped) brings it back up.
+uptime_restart_minutes = 0
 
 [database]
 engine = "sqlite"


### PR DESCRIPTION
## Problem

The prod server auto-restarts on a timer (`server.uptime_restart_minutes = 480`, 8h) **even while players are connected** — it kicks the whole lobby.

## Root cause

There are two paths to `DoShutdown()` in `Content.Server/ServerUpdates/ServerUpdateManager.cs`, and only one guards against connected players:

- **Empty-server path** (`ServerEmptyUpdateRestartCheck`) checks `playersOnline` and defers via a 20s timer that aborts if someone connects. ✅
- **Round-end path** (`RoundEnded()`, line 80) has **no** player-online guard — it calls `DoShutdown()` immediately when `ShouldShutdownDueToUptime()` is true. It's invoked from `GameTicker.RestartRound()` at the round transition, when every player from the round is still connected. ❌

So on a populated 24/7 server, the first round end after 8h uptime restarts the process with the full playerbase online.

## Change

Set `uptime_restart_minutes = 0` (engine default = disabled) in `Docker/server_config.prod.toml`, and update the comment. Rely on Docker restart-on-crash / manual restarts when empty instead.

No engine/upstream code changed — this is config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)